### PR TITLE
Added an implementation to calculate menu paths

### DIFF
--- a/PokemonXDRNGLibrary/AdvancePlanning/MenuAdvancePlanner.cs
+++ b/PokemonXDRNGLibrary/AdvancePlanning/MenuAdvancePlanner.cs
@@ -13,7 +13,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace PokemonXDRNGLibrary.AdvanceSource
+namespace PokemonXDRNGLibrary.AdvancePlanning
 {
     public enum Menus
     {
@@ -35,9 +35,9 @@ namespace PokemonXDRNGLibrary.AdvanceSource
 
         public MenuInput(Menus menu, uint advances, uint nextSeed)
         {
-            this.Menu = menu;
-            this.Advances = advances;
-            this.NextSeed = nextSeed;
+            Menu = menu;
+            Advances = advances;
+            NextSeed = nextSeed;
         }
 
         public override string ToString() // makes looking at debug values easier
@@ -126,7 +126,7 @@ namespace PokemonXDRNGLibrary.AdvanceSource
         private uint NameScreen(uint seed) => seed.NextSeed(2);
 
         // best to keep targetAdvances in the range of ]0:150000] 
-        public List<Queue<MenuInput>> FindPaths(uint startSeed, uint targetAdvances, bool palVersion, Menus start,  uint maxNameScreens, uint maxRumbleSaves, CancellationToken token)
+        public List<Queue<MenuInput>> FindPaths(uint startSeed, uint targetAdvances, bool palVersion, Menus start, uint maxNameScreens, uint maxRumbleSaves, CancellationToken token)
         {
             var path = new Queue<MenuInput>();
             attemptedPaths?.Clear();

--- a/PokemonXDRNGLibrary/AdvanceSource/MenuAdvancePlanner.cs
+++ b/PokemonXDRNGLibrary/AdvanceSource/MenuAdvancePlanner.cs
@@ -1,0 +1,257 @@
+﻿using PokemonPRNG.LCG32;
+using PokemonPRNG.LCG32.GCLCG;
+using PokemonXDRNGLibrary.GroupBattle;
+using PokemonXDRNGLibrary.QuickBattle;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PokemonXDRNGLibrary.AdvanceSource
+{
+    public enum Menus
+    {
+        MainMenu,
+        VSMode,
+        QuickBattle,
+        GroupBattle,
+        AnyDifficulty, //TODO rename to CPUBattle
+        // TwoPlayerBattle,
+        RumbleSave,
+        Namescreen,
+    }
+
+    public struct MenuInput
+    {
+        public Menus Menu { get; set; }
+        public uint Advances { get; set; }
+        public uint NextSeed { get; set; }
+
+        public MenuInput(Menus menu, uint advances, uint nextSeed)
+        {
+            this.Menu = menu;
+            this.Advances = advances;
+            this.NextSeed = nextSeed;
+        }
+
+        public override string ToString() // makes looking at debug values easier
+        {
+            return $"{Menu} | {Advances} | {NextSeed:X}";
+        }
+    }
+
+    public class MenuAdvancePlanner
+    {
+        private readonly Dictionary<Menus, Dictionary<Menus, Func<uint, uint>>> graph;
+        private readonly QuickBattleGenerator qbGenerator;
+        private readonly GroupBattleGenerator gbGenerator;
+        private HashSet<(Menus, uint)> attemptedPaths = new HashSet<(Menus, uint)>();
+        private List<Queue<MenuInput>> paths = new List<Queue<MenuInput>>();
+
+        public MenuAdvancePlanner(uint tsv)
+        {
+            graph = new Dictionary<Menus, Dictionary<Menus, Func<uint, uint>>>()
+            {
+                {
+                    Menus.MainMenu,
+                    new Dictionary<Menus, Func<uint, uint>>()
+                    {
+                        { Menus.VSMode, NoAdvances },
+                        { Menus.RumbleSave, RumbleSave },
+                        { Menus.Namescreen, NameScreen }
+                    }
+                },
+                {
+                    Menus.VSMode,
+                    new Dictionary<Menus, Func<uint, uint>>()
+                    {
+                        { Menus.QuickBattle, QuickBattle },
+                        { Menus.GroupBattle, GroupBattle },
+                        { Menus.MainMenu, NoAdvances }
+                    }
+                },
+                {
+                    Menus.QuickBattle,
+                    new Dictionary<Menus, Func<uint, uint>>()
+                    {
+                        { Menus.VSMode, NoAdvances },
+                        { Menus.AnyDifficulty, AnyDifficulty }
+                    }
+                },
+                {
+                    Menus.GroupBattle,
+                    new Dictionary<Menus, Func<uint, uint>>()
+                    {
+                        { Menus.VSMode, NoAdvances }
+                    }
+                },
+                {
+                    Menus.AnyDifficulty,
+                    new Dictionary<Menus, Func<uint, uint>>()
+                    {
+                        { Menus.QuickBattle, NoAdvances }
+                    }
+                },
+                {
+                    Menus.RumbleSave,
+                    new Dictionary<Menus, Func<uint, uint>>()
+                    {
+                        { Menus.MainMenu, NoAdvances }
+                    }
+                },
+                {
+                    Menus.Namescreen,
+                    new Dictionary<Menus, Func<uint, uint>>()
+                    {
+                        { Menus.MainMenu, NoAdvances }
+                    }
+                }
+            };
+
+            qbGenerator = new QuickBattleGenerator(tsv);
+            gbGenerator = new GroupBattleGenerator(tsv);
+        }
+
+        private uint QuickBattle(uint seed) => qbGenerator.EnterQuickBattle(seed);
+        private uint GroupBattle(uint seed) => gbGenerator.EnterGroupBattle(seed);
+        private uint AnyDifficulty(uint seed) => qbGenerator.Use(seed); //TODO add node for TwoPlayerBattle
+        private uint NoAdvances(uint seed) => seed;
+        private uint RumbleSave(uint seed) => seed.NextSeed(40);
+        private uint NameScreen(uint seed) => seed.NextSeed(2);
+
+        // best to keep targetAdvances in the range of ]0:150000] 
+        public List<Queue<MenuInput>> FindPaths(uint startSeed, uint targetAdvances, bool palVersion, Menus start,  uint maxNameScreens, uint maxRumbleSaves, CancellationToken token)
+        {
+            var path = new Queue<MenuInput>();
+            attemptedPaths?.Clear();
+            paths?.Clear();
+            uint rumbleSaves = 0;
+            uint nameScreens = 0;
+
+            var restrictions = new SearchRestrictions(maxRumbleSaves, maxNameScreens, rumbleSaves, nameScreens, palVersion);
+            FindPaths(startSeed, targetAdvances, start, restrictions, path, token);
+
+            return paths;
+        }
+
+        private void FindPaths(uint startSeed, uint targetAdvances, Menus start, SearchRestrictions restrictions, Queue<MenuInput> path, CancellationToken token)
+        {
+            if (token.IsCancellationRequested) return;
+            foreach (var route in graph[start])
+            {
+                // already tried this option from this seed -> each path only gets checked once
+                if (!attemptedPaths.Add((route.Key, startSeed)))
+                    continue;
+                if (!restrictions.Check(route.Key))
+                    continue;
+
+                var currentPath = new Queue<MenuInput>(path);
+
+                uint nextSeed = route.Value(startSeed);
+                uint advances = nextSeed.GetIndex(startSeed);
+
+                currentPath.Enqueue(new MenuInput(route.Key, advances, nextSeed));
+
+                long sum = currentPath.Sum(_ => _.Advances);
+
+                if (sum == targetAdvances)
+                    paths.Add(currentPath);
+                else if (sum > targetAdvances)
+                    continue;
+                else
+                    FindPaths(nextSeed, targetAdvances, route.Key, restrictions, currentPath, token);
+            }
+
+        }
+
+        private struct SearchRestrictions
+        {
+            public uint maxRumbleSaves;
+            public uint maxNameScreens;
+            public uint rumbleSaves;
+            public uint nameScreens;
+            public bool palVersion;
+
+            public SearchRestrictions(uint maxRumbleSaves, uint maxNameScreens, uint rumbleSaves, uint nameScreens, bool palVersion)
+            {
+                this.maxRumbleSaves = maxRumbleSaves;
+                this.maxNameScreens = maxNameScreens;
+                this.rumbleSaves = rumbleSaves;
+                this.nameScreens = nameScreens;
+                this.palVersion = palVersion;
+            }
+
+            public bool Check(Menus nextMenu)
+            {
+                // this can be as high as it wants and by using x++ instead of ++x it avoids an off by 1 scenario for ==
+                if (nextMenu == Menus.RumbleSave && rumbleSaves++ >= maxRumbleSaves)
+                    return false;
+                // this can be as high as it wants and by using x++ instead of ++x it avoids an off by 1 scenario for ==
+                else if (nextMenu == Menus.Namescreen && (!palVersion || nameScreens++ >= maxNameScreens))
+                    return false;
+                else
+                    return true;
+            }
+        }
+
+
+        #region old implementation without struct
+
+        [Obsolete]
+        public List<Queue<MenuInput>> FindPaths_Old(uint startSeed, uint targetAdvances, bool palVersion, Menus start, uint maxNameScreens, uint maxRumbleSaves, CancellationToken token)
+        {
+            var path = new Queue<MenuInput>();
+            attemptedPaths?.Clear();
+            paths?.Clear();
+            uint rumbleSaves = 0;
+            uint nameScreens = 0;
+
+            FindPaths_Old(startSeed, targetAdvances, palVersion, start, maxRumbleSaves, maxNameScreens, rumbleSaves, nameScreens, path, token);
+
+            return paths;
+        }
+
+        [Obsolete]
+        private void FindPaths_Old(uint startSeed, uint targetAdvances, bool palVersion, Menus start, uint maxRumbleSaves, uint maxNameScreens, uint rumbleSaves, uint nameScreens, Queue<MenuInput> path, CancellationToken token)
+        {
+            if (token.IsCancellationRequested) return;
+            foreach (var route in graph[start])
+            {
+                // already tried this option from this seed -> each path only gets checked once
+                if (!attemptedPaths.Add((route.Key, startSeed)))
+                    continue;
+                // this can be as high as it wants and by using x++ instead of ++x it avoids and off by 1 scenario for ==
+                if (route.Key == Menus.RumbleSave && rumbleSaves++ >= maxRumbleSaves)
+                    continue;
+                // this can be as high as it wants and by using x++ instead of ++x it avoids and off by 1 scenario for ==
+                else if (route.Key == Menus.Namescreen && (!palVersion || nameScreens++ >= maxNameScreens))
+                    continue;
+
+                var currentPath = new Queue<MenuInput>(path);
+
+                uint nextSeed = route.Value(startSeed);
+                uint advances = nextSeed.GetIndex(startSeed);
+
+                currentPath.Enqueue(new MenuInput(route.Key, advances, nextSeed));
+
+                long sum = currentPath.Sum(_ => _.Advances);
+
+                if (sum == targetAdvances)
+                    paths.Add(currentPath);
+                else if (sum > targetAdvances)
+                    continue;
+                else
+                    FindPaths_Old(nextSeed, targetAdvances, palVersion, route.Key, maxRumbleSaves, maxNameScreens, rumbleSaves, nameScreens, currentPath, token);
+            }
+
+        }
+
+        #endregion
+    }
+}

--- a/PokemonXDRNGLibrary/Core/GCIndividual.cs
+++ b/PokemonXDRNGLibrary/Core/GCIndividual.cs
@@ -19,7 +19,7 @@ namespace PokemonXDRNGLibrary
             this.GCAbility = species.Ability[(int)gcAbility];
             this.ShinySkipped = shinySkipped;
         }
-        internal GCIndividual(Pokemon.Species species, uint pid, uint[] ivs, uint[] evs, uint lv, uint gcAbility, bool shinySkipped) : base(species, pid, ivs, lv)
+        internal GCIndividual(Pokemon.Species species, uint pid, uint[] ivs, uint[] evs, uint lv, uint gcAbility, bool shinySkipped) : base(species, pid, ivs, lv, evs)
         {
             this.GCAbility = species.Ability[(int)gcAbility];
             this.ShinySkipped = shinySkipped;

--- a/PokemonXDRNGLibrary/Core/GCSlot.cs
+++ b/PokemonXDRNGLibrary/Core/GCSlot.cs
@@ -4,6 +4,8 @@ using PokemonStandardLibrary;
 using PokemonStandardLibrary.Gen3;
 using PokemonStandardLibrary.CommonExtension;
 using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace PokemonXDRNGLibrary
 {
@@ -123,9 +125,27 @@ namespace PokemonXDRNGLibrary
 
             _pidGenerator = new BasicPIDGenerator();
         }
+        internal GCSlot(string name, string form)
+        {
+            Species = Pokemon.GetPokemon(name, form);
+            Lv = 50;
+            FixedGender = Gender.Genderless;
+            FixedNature = Nature.other;
+
+            _pidGenerator = new BasicPIDGenerator();
+        }
         internal GCSlot(string name, Gender gender, Nature nature)
         {
             Species = Pokemon.GetPokemon(name);
+            Lv = 50;
+            FixedGender = gender;
+            FixedNature = nature;
+
+            _pidGenerator = GetPIDGenerator(nature, Species, gender);
+        }
+        internal GCSlot(string name, string form, Gender gender, Nature nature)
+        {
+            Species = Pokemon.GetPokemon(name, form);
             Lv = 50;
             FixedGender = gender;
             FixedNature = nature;

--- a/PokemonXDRNGLibrary/Core/XDRNGSystem.cs
+++ b/PokemonXDRNGLibrary/Core/XDRNGSystem.cs
@@ -37,6 +37,27 @@ namespace PokemonXDRNGLibrary
             return EVs;
         }
 
+        // see https://sina-poke.hatenablog.com/entry/2022/04/23/021304
+        public static uint[] GenerateEVsDummy(ref this uint seed)
+        {
+            uint[] EVs = new uint[6];
+            for (int i = 0; i < 101; i++)
+            {
+                uint sumEV = 0;
+                for (int j = 0; j < 6; j++)
+                {
+                    EVs[j] += seed.GetRand() & 0xFF;
+                    sumEV += EVs[j];
+                }
+
+                if (sumEV <= 510) return EVs;
+                else if (i >= 100) continue;
+                else EVs = new uint[6];
+            }
+
+            return EVs;
+        }
+
         internal static readonly IReadOnlyList<XDDarkPokemon> XDDarkPokemonList;
         internal static readonly Dictionary<string, XDDarkPokemon> XDDarkPokemonDictionary;
 

--- a/PokemonXDRNGLibrary/GroupBattle/GroupBattleGenerator.cs
+++ b/PokemonXDRNGLibrary/GroupBattle/GroupBattleGenerator.cs
@@ -1,0 +1,74 @@
+﻿using PokemonPRNG.LCG32.GCLCG;
+using PokemonStandardLibrary;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PokemonXDRNGLibrary.GroupBattle
+{
+    // see https://sina-poke.hatenablog.com/entry/2022/04/23/021304
+    public class GroupBattleGenerator
+    {
+        private static readonly GCSlot[] dummies = new GCSlot[]
+        {
+            new GCSlot("Dummy", "Genderless"),
+            new GCSlot("Dummy", "M1F1", Gender.Male, Nature.Impish),
+            new GCSlot("Dummy", "M3F1", Gender.Male, Nature.Impish),
+            new GCSlot("Dummy", "Genderless", Gender.Genderless, Nature.Naive),
+            new GCSlot("Dummy", "Genderless", Gender.Genderless, Nature.Relaxed),
+            new GCSlot("Dummy", "M1F1", Gender.Male, Nature.Rash)
+        };
+
+        private readonly uint _tsv;
+
+        public uint EnterGroupBattle(uint seed)
+        {
+            seed.Advance(122);
+
+            uint tid = seed.GetRand();
+            uint sid = seed.GetRand();
+            uint tsv = tid ^ sid;
+
+            for (int i = 0; i < 3; i++)
+            {
+                dummies[0].Use(ref seed, tsv);
+                seed.GenerateEVsDummy();
+            }
+
+            dummies[1].Use(ref seed, tsv);
+            dummies[1].Use(ref seed, tsv);
+            dummies[2].Use(ref seed, tsv);
+
+            tid = seed.GetRand();
+            sid = seed.GetRand();
+            tsv = tid ^ sid;
+
+            dummies[0].Use(ref seed, tsv);
+            seed.GenerateEVsDummy();
+
+            dummies[3].Use(ref seed, tsv);
+
+            tid = seed.GetRand();
+            sid = seed.GetRand();
+            tsv = tid ^ sid;
+
+            dummies[4].Use(ref seed, tsv);
+            dummies[5].Use(ref seed, tsv);
+
+            tid = seed.GetRand();
+            sid = seed.GetRand();
+            tsv = tid ^ sid;
+
+            for (int i = 0; i < 2; i++)
+            {
+                dummies[0].Use(ref seed, tsv);
+                seed.GenerateEVsDummy();
+            }
+
+            return seed;
+        }
+
+        public GroupBattleGenerator(uint tsv)
+            => _tsv = tsv;
+    }
+}

--- a/PokemonXDRNGLibrary/GroupBattle/GroupBattleGenerator.cs
+++ b/PokemonXDRNGLibrary/GroupBattle/GroupBattleGenerator.cs
@@ -2,22 +2,21 @@
 using PokemonStandardLibrary;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace PokemonXDRNGLibrary.GroupBattle
 {
     // see https://sina-poke.hatenablog.com/entry/2022/04/23/021304
     public class GroupBattleGenerator
     {
-        private static readonly GCSlot[] dummies = new GCSlot[]
-        {
-            new GCSlot("Dummy", "Genderless"),
-            new GCSlot("Dummy", "M1F1", Gender.Male, Nature.Impish),
-            new GCSlot("Dummy", "M3F1", Gender.Male, Nature.Impish),
-            new GCSlot("Dummy", "Genderless", Gender.Genderless, Nature.Naive),
-            new GCSlot("Dummy", "Genderless", Gender.Genderless, Nature.Relaxed),
-            new GCSlot("Dummy", "M1F1", Gender.Male, Nature.Rash)
-        };
+        private static readonly GCSlot dummyGenderless = new GCSlot("Dummy", "Genderless");
+        private static readonly GCSlot dummyM1F1MaleImpish = new GCSlot("Dummy", "M1F1", Gender.Male, Nature.Impish);
+        private static readonly GCSlot dummyM3F1MaleImpish = new GCSlot("Dummy", "M3F1", Gender.Male, Nature.Impish);
+        private static readonly GCSlot dummyGenderlessNaive = new GCSlot("Dummy", "Genderless", Gender.Genderless, Nature.Naive);
+        private static readonly GCSlot dummyGenderlessRelaxed = new GCSlot("Dummy", "Genderless", Gender.Genderless, Nature.Relaxed);
+        private static readonly GCSlot dummyM1F1MaleRash = new GCSlot("Dummy", "M1F1", Gender.Male, Nature.Rash);
 
         private readonly uint _tsv;
 
@@ -31,29 +30,29 @@ namespace PokemonXDRNGLibrary.GroupBattle
 
             for (int i = 0; i < 3; i++)
             {
-                dummies[0].Use(ref seed, tsv);
+                dummyGenderless.Use(ref seed, tsv);
                 seed.GenerateEVsDummy();
             }
 
-            dummies[1].Use(ref seed, tsv);
-            dummies[1].Use(ref seed, tsv);
-            dummies[2].Use(ref seed, tsv);
+            dummyM1F1MaleImpish.Use(ref seed, tsv);
+            dummyM1F1MaleImpish.Use(ref seed, tsv);
+            dummyM3F1MaleImpish.Use(ref seed, tsv);
 
             tid = seed.GetRand();
             sid = seed.GetRand();
             tsv = tid ^ sid;
 
-            dummies[0].Use(ref seed, tsv);
+            dummyGenderless.Use(ref seed, tsv);
             seed.GenerateEVsDummy();
 
-            dummies[3].Use(ref seed, tsv);
+            dummyGenderlessNaive.Use(ref seed, tsv);
 
             tid = seed.GetRand();
             sid = seed.GetRand();
             tsv = tid ^ sid;
 
-            dummies[4].Use(ref seed, tsv);
-            dummies[5].Use(ref seed, tsv);
+            dummyGenderlessRelaxed.Use(ref seed, tsv);
+            dummyM1F1MaleRash.Use(ref seed, tsv);
 
             tid = seed.GetRand();
             sid = seed.GetRand();
@@ -61,7 +60,7 @@ namespace PokemonXDRNGLibrary.GroupBattle
 
             for (int i = 0; i < 2; i++)
             {
-                dummies[0].Use(ref seed, tsv);
+                dummyGenderless.Use(ref seed, tsv);
                 seed.GenerateEVsDummy();
             }
 

--- a/PokemonXDRNGLibrary/QuickBattle/QuickBattleGenerator.cs
+++ b/PokemonXDRNGLibrary/QuickBattle/QuickBattleGenerator.cs
@@ -22,10 +22,7 @@ namespace PokemonXDRNGLibrary.QuickBattle
             (new GCSlot("ラティアス"), new GCSlot("ゲンガー")),
         };
 
-        private static readonly GCSlot[] dummies = new GCSlot[]
-        {
-            new GCSlot("Dummy", "Genderless")
-        };
+        private static readonly GCSlot dummy = new GCSlot("Dummy", "Genderless");
 
         private static readonly string[] battleField = new [] { "パイラ", "ラルガ", "バトル山", "岩場", "オアシス", "洞窟" };
 
@@ -56,8 +53,6 @@ namespace PokemonXDRNGLibrary.QuickBattle
                 playerTeam[playerTeamIndex].First.GenerateDummy(ref seed, _tsv),
                 playerTeam[playerTeamIndex].Second.GenerateDummy(ref seed, _tsv)
             );
-
-            GenerateDummy(ref seed, ref playerTSV, pTeam.Item1.PID, pTeam.Item2.PID);
 
             return new QuickBattleResult(pTeam, eTeam, field, ((PlayerTeam)playerTeamIndex, (EnemyTeam)enemyTeamIndex));
         }
@@ -122,8 +117,6 @@ namespace PokemonXDRNGLibrary.QuickBattle
                 selectedTable[player1TeamIndex].Second.GenerateDummy(ref seed, _tsv)
             );
 
-            GenerateDummy(ref seed, ref player1TSV, p1Team.Item1.PID, p1Team.Item2.PID);
-
             return new TwoPlayerResult(p1Team, p2Team, field);
         }
 
@@ -180,7 +173,7 @@ namespace PokemonXDRNGLibrary.QuickBattle
 
                 for (int j = 0; j < 2; j++)
                 {
-                    dummies[0].Use(ref seed, tsv);
+                    dummy.Use(ref seed, tsv);
                     seed.GenerateEVsDummy();
                 }
             }

--- a/PokemonXDRNGLibrary/QuickBattle/QuickBattleGenerator.cs
+++ b/PokemonXDRNGLibrary/QuickBattle/QuickBattleGenerator.cs
@@ -22,6 +22,11 @@ namespace PokemonXDRNGLibrary.QuickBattle
             (new GCSlot("ラティアス"), new GCSlot("ゲンガー")),
         };
 
+        private static readonly GCSlot[] dummies = new GCSlot[]
+        {
+            new GCSlot("Dummy", "Genderless")
+        };
+
         private static readonly string[] battleField = new [] { "パイラ", "ラルガ", "バトル山", "岩場", "オアシス", "洞窟" };
 
         private readonly uint _tsv;
@@ -29,51 +34,175 @@ namespace PokemonXDRNGLibrary.QuickBattle
         public QuickBattleResult Generate(uint seed)
         {
             seed.Advance();
-            var playerTeamIndex = seed.GetRand(5);
-            var enemyTeamIndex = seed.GetRand(5);
+            uint playerTeamIndex = seed.GetRand(5);
+            uint enemyTeamIndex = seed.GetRand(5);
 
-            var field = battleField[seed.GetRand(6)];
-            var enemyTSV = seed.GetRand() ^ seed.GetRand();
+            string field = battleField[seed.GetRand(6)];
+
+            uint enemyTSV = seed.GetRand() ^ seed.GetRand();
+
             var eTeam = (
-                enemyTeam[enemyTeamIndex].First.GenerateDummy(ref seed, enemyTSV),
-                enemyTeam[enemyTeamIndex].Second.GenerateDummy(ref seed, enemyTSV)
+                enemyTeam[enemyTeamIndex].First.GenerateDummy(ref seed, _tsv),
+                enemyTeam[enemyTeamIndex].Second.GenerateDummy(ref seed, _tsv)
             );
 
-            seed.Advance(3);
+            GenerateDummy(ref seed, ref enemyTSV, eTeam.Item1.PID, eTeam.Item2.PID);
+
+            seed.Advance();
+
+            uint playerTSV = seed.GetRand() ^ seed.GetRand();
 
             var pTeam = (
                 playerTeam[playerTeamIndex].First.GenerateDummy(ref seed, _tsv),
                 playerTeam[playerTeamIndex].Second.GenerateDummy(ref seed, _tsv)
             );
+
+            GenerateDummy(ref seed, ref playerTSV, pTeam.Item1.PID, pTeam.Item2.PID);
 
             return new QuickBattleResult(pTeam, eTeam, field, ((PlayerTeam)playerTeamIndex, (EnemyTeam)enemyTeamIndex));
         }
+
         public QuickBattleResult Generate(ref uint seed)
         {
             seed.Advance();
-            var playerTeamIndex = seed.GetRand(5);
-            var enemyTeamIndex = seed.GetRand(5);
+            uint playerTeamIndex = seed.GetRand(5);
+            uint enemyTeamIndex = seed.GetRand(5);
 
-            var field = battleField[seed.GetRand(6)];
-            var enemyTSV = seed.GetRand() ^ seed.GetRand();
+            string field = battleField[seed.GetRand(6)];
+
+            uint enemyTSV = seed.GetRand() ^ seed.GetRand();
+
             var eTeam = (
-                enemyTeam[enemyTeamIndex].First.GenerateDummy(ref seed, enemyTSV),
-                enemyTeam[enemyTeamIndex].Second.GenerateDummy(ref seed, enemyTSV)
+                enemyTeam[enemyTeamIndex].First.GenerateDummy(ref seed, _tsv),
+                enemyTeam[enemyTeamIndex].Second.GenerateDummy(ref seed, _tsv)
             );
 
-            seed.Advance(3);
+            GenerateDummy(ref seed, ref enemyTSV, eTeam.Item1.PID, eTeam.Item2.PID);
+
+            seed.Advance();
+
+            uint playerTSV = seed.GetRand() ^ seed.GetRand();
 
             var pTeam = (
                 playerTeam[playerTeamIndex].First.GenerateDummy(ref seed, _tsv),
                 playerTeam[playerTeamIndex].Second.GenerateDummy(ref seed, _tsv)
             );
 
+            GenerateDummy(ref seed, ref playerTSV, pTeam.Item1.PID, pTeam.Item2.PID);
+
             return new QuickBattleResult(pTeam, eTeam, field, ((PlayerTeam)playerTeamIndex, (EnemyTeam)enemyTeamIndex));
+        }
+
+        public TwoPlayerResult GenerateTwoPlayers(uint seed) //TODO test this for edge cases
+        {
+            seed.Advance();
+            uint player1TeamIndex = seed.GetRand(5);
+            uint player2TeamIndex;
+            do { player2TeamIndex = seed.GetRand(5); } while (player2TeamIndex == player1TeamIndex);
+
+            var selectedTable = ((seed.GetRand() & 0x80u) != 0u) ? enemyTeam : playerTeam;
+
+            string field = battleField[seed.GetRand(6)];
+
+            uint player2TSV = seed.GetRand() ^ seed.GetRand();
+
+            var p2Team = (
+                selectedTable[player2TeamIndex].First.GenerateDummy(ref seed, _tsv),
+                selectedTable[player2TeamIndex].Second.GenerateDummy(ref seed, _tsv)
+            );
+
+            GenerateDummy(ref seed, ref player2TSV, p2Team.Item1.PID, p2Team.Item2.PID);
+
+            seed.Advance();
+
+            uint player1TSV = seed.GetRand() ^ seed.GetRand();
+
+            var p1Team = (
+                selectedTable[player1TeamIndex].First.GenerateDummy(ref seed, _tsv),
+                selectedTable[player1TeamIndex].Second.GenerateDummy(ref seed, _tsv)
+            );
+
+            GenerateDummy(ref seed, ref player1TSV, p1Team.Item1.PID, p1Team.Item2.PID);
+
+            return new TwoPlayerResult(p1Team, p2Team, field);
+        }
+
+        public TwoPlayerResult GenerateTwoPlayers(ref uint seed) //TODO test this for edge cases
+        {
+            seed.Advance();
+            uint player1TeamIndex = seed.GetRand(5);
+            uint player2TeamIndex;
+            do { player2TeamIndex = seed.GetRand(5); } while (player2TeamIndex == player1TeamIndex);
+
+            var selectedTable = ((seed.GetRand() & 0x80u) != 0u) ? enemyTeam : playerTeam;
+
+            string field = battleField[seed.GetRand(6)];
+
+            uint player2TSV = seed.GetRand() ^ seed.GetRand();
+
+            var p2Team = (
+                selectedTable[player2TeamIndex].First.GenerateDummy(ref seed, _tsv),
+                selectedTable[player2TeamIndex].Second.GenerateDummy(ref seed, _tsv)
+            );
+
+            GenerateDummy(ref seed, ref player2TSV, p2Team.Item1.PID, p2Team.Item2.PID);
+
+            seed.Advance();
+
+            uint player1TSV = seed.GetRand() ^ seed.GetRand();
+
+            var p1Team = (
+                selectedTable[player1TeamIndex].First.GenerateDummy(ref seed, _tsv),
+                selectedTable[player1TeamIndex].Second.GenerateDummy(ref seed, _tsv)
+            );
+
+            GenerateDummy(ref seed, ref player1TSV, p1Team.Item1.PID, p1Team.Item2.PID);
+
+            return new TwoPlayerResult(p1Team, p2Team, field);
+        }
+
+        public uint Use(uint seed)
+        {
+            uint seedCopy = seed;
+            Generate(ref seedCopy);
+
+            return seedCopy;
+        }
+
+        // see https://sina-poke.hatenablog.com/entry/2022/04/23/021304
+        public uint EnterQuickBattle(uint seed)
+        {
+            seed.Advance(122);
+
+            for (int i = 0; i < 4; i++)
+            {
+                uint tsv = seed.GetRand() ^ seed.GetRand();
+
+                for (int j = 0; j < 2; j++)
+                {
+                    dummies[0].Use(ref seed, tsv);
+                    seed.GenerateEVsDummy();
+                }
+            }
+            return seed;
+        }
+
+        // see https://sina-poke.hatenablog.com/entry/2024/02/08/000000
+        private void GenerateDummy(ref uint seed, ref uint tsv, params uint[] pids)
+        {
+            foreach (uint pid in pids)
+            {
+                while (pid.IsShiny(tsv))
+                {
+                    tsv = seed.GetRand() ^ seed.GetRand();
+                }
+            }
         }
 
         public QuickBattleGenerator(uint tsv)
             => _tsv = tsv;
     }
+
     public class QuickBattleResult
     {
         public (GCIndividual First, GCIndividual Second) PlayerTeam { get; }
@@ -87,6 +216,20 @@ namespace PokemonXDRNGLibrary.QuickBattle
             EnemyTeam = e;
             BattleField = battleField;
             GeneratedTeams = generatedTeams;
+        }
+    }
+
+    public class TwoPlayerResult
+    {
+        public (GCIndividual First, GCIndividual Second) Player1Team { get; }
+        public (GCIndividual First, GCIndividual Second) Player2Team { get; }
+        public string BattleField { get; }
+
+        public TwoPlayerResult((GCIndividual First, GCIndividual Second) p1, (GCIndividual First, GCIndividual Second) p2, string battleField)
+        {
+            Player1Team = p1;
+            Player2Team = p2;
+            BattleField = battleField;
         }
     }
 }


### PR DESCRIPTION
- adjusted QuickBattle to consider the shiny check against the dummy tsv
  see https://sina-poke.hatenablog.com/entry/2024/02/08/000000
- added the logic for EnterGroupBattle and EnterQuickBattle
  see https://sina-poke.hatenablog.com/entry/2022/04/23/021304
- added the logic for TwoPlayerBattle
- includes an algorithm that uses a graph to calculate paths that add up to a specified amount of advances/consumption
- fixed a little bug where the pokemon's stats got generated without EVs
- added constructors to GCSlot that include the form for the species

MenuAdvancePlanner uses this graph to calculate paths (TwoPlayerBattle not included yet)
![image](https://github.com/user-attachments/assets/82510889-c59d-40ae-907c-117db3507ea9)
