### PR TITLE
Fixed a bug where EnterQuickBattle only checked for shinyness against the dummy tsv

### DIFF
--- a/PokemonXDRNGLibrary/QuickBattle/QuickBattleGenerator.cs
+++ b/PokemonXDRNGLibrary/QuickBattle/QuickBattleGenerator.cs
@@ -173,7 +173,8 @@ namespace PokemonXDRNGLibrary.QuickBattle
 
                 for (int j = 0; j < 2; j++)
                 {
-                    dummy.Use(ref seed, tsv);
+                    var result = dummy.Generate(ref seed, _tsv);
+                    GenerateDummy(ref seed, ref tsv, result.PID);
                     seed.GenerateEVsDummy();
                 }
             }


### PR DESCRIPTION
Someone ran into a problem where entering the menu didn't produce the expected seed.
Details can be found [here](https://x.com/John_9299/status/1884807559250403465)

